### PR TITLE
bugfix: _batch_inference needs to always `yield`

### DIFF
--- a/msclap/CLAPWrapper.py
+++ b/msclap/CLAPWrapper.py
@@ -312,7 +312,7 @@ class CLAPWrapper():
             # batch size is bigger than available audio/text items
             if next_batch_idx >= args0_len:
                 inputs[0] = input_tmp[dataset_idx:]
-                return func(*tuple(inputs))
+                yield func(*tuple(inputs))
             else:
                 inputs[0] = input_tmp[dataset_idx:next_batch_idx]
                 yield func(*tuple(inputs))


### PR DESCRIPTION
`_generic_batch_inference` returns a generator, but will not correctly return the last item.  The currently implementation incorrectly `returns` the last item instead of `yield`ing it. 