### PR TITLE
[deps] Bump numpy/librosa for numpy 2.x compatibility; make torch family optional, fixes #48

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "msclap"
-version = "1.3.3"
+version = "1.3.5"
 description = "CLAP (Contrastive Language-Audio Pretraining) is a model that learns acoustic concepts from natural language supervision and enables “Zero-Shot” inference. The model has been extensively evaluated in 26 audio downstream tasks achieving SoTA in several of them including classification, retrieval, and captioning."
 authors = ["Benjamin Elizalde", "Soham Deshmukh", "Huaming Wang"]
 license = "MIT"
@@ -11,16 +11,19 @@ packages = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-librosa = "^0.10.1"
-numpy = "^1.23.0"
+librosa = ">=0.11.0"
+numpy = ">=2.2.6"
 pandas = "^2.0.0"
-torch = "^2.1.0"
-torchaudio = "^2.1.0"
-torchlibrosa = "^0.1.0"
+torch = {version = ">=2.1.0", optional = true}
+torchaudio = {version = ">=2.1.0", optional = true}
+torchlibrosa = {version = "^0.1.0", optional = true}
 tqdm = "^4.66.1"
 transformers = "^4.34.0"
 pyyaml = "^6.0.1"
 scikit-learn = "^1.3.1"
+
+[tool.poetry.extras]
+torch = ["torch", "torchaudio", "torchlibrosa"]
 
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ torch = {version = ">=2.1.0", optional = true}
 torchaudio = {version = ">=2.1.0", optional = true}
 torchlibrosa = {version = "^0.1.0", optional = true}
 tqdm = "^4.66.1"
-transformers = "^4.34.0"
+transformers = ">=4.34.0"
 pyyaml = "^6.0.1"
 scikit-learn = "^1.3.1"
 


### PR DESCRIPTION
## Description:                                                                                                        
                                                                                                                      
### Summary                                                                                                             
                                                                                                                      
This PR updates pyproject.toml to unblock users who need numpy >= 2.x and librosa >= 0.11.0, which are increasingly required by modern audio/ML stacks. No changes were made to any source code.                                        
                                                                                                                      
### Changes                                                                                                             
                                                                                                              
- librosa: ^0.10.1 → >=0.11.0                                                                                       
- numpy: ^1.23.0 → >=2.2.6                                                                                          
- torch, torchaudio, torchlibrosa: moved to optional, exposed via pip install msclap[torch]                         
                                                                                                                      
Why make torch optional?                                                                                            
                                                                                                            
torch and its sibling libraries (torchaudio, torchlibrosa) are highly environment-sensitive. The correct version    
depends on the user's CUDA version, driver, and other installed torch-family packages - and they must all match     
exactly. Installing torch from PyPI as a hard dependency frequently results in a CPU-only build being pulled in,    
silently overriding a user's carefully configured GPU environment.                                                  
                                                                                                            
The established convention in the ML ecosystem (e.g. accelerate, sentence-transformers) is to treat torch as a      
pre-condition that users manage themselves via the official PyTorch install matrix. Making it optional in           
pyproject.toml respects that convention without removing any functionality.                                         
                                                                                                            
Testing                                                                                                            
                                                                                                            
All example scripts were executed successfully without any modifications to source code:                            
                                                                                                            
- examples/zero_shot_predictions.py                                                                                 
- examples/zero_shot_classification.py                                                                              
- examples/audio_captioning.py                                                                                      
                                                                                                            
Test environment:                                                                                                   
                                                                                                            
                                                                                
| Package | Version |
| ------------ | ----------- |                                                                     
| Python | 3.10.8 |
| numpy | 2.26 |
| librosa | 0.11.0 |
| torch | 2.8.0+cu129 |
| torchaudio | 2.8.0+cu129 |
| torchlibrosa | 0.1.0 |
| pandas | 2.3.3 |
| transformers | 4.39.0 |
|pyyaml | 6.0.2 |
| scikit-learn | 1.7.2 |
                                                                      
Since no source code was modified, the behavior is identical to the current release - this is purely a dependency   
constraint update.  